### PR TITLE
Update seeders 2

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -109,7 +109,8 @@ public:
 
         vFixedSeeds.clear();
         vSeeds.clear();
-        vSeeds.push_back(CDNSSeedData("blockoperations.com", "zpool.blockoperations.com/"));
+        vSeeds.push_back(CDNSSeedData("zensystem.io", "dnsseed.zensystem.io"));
+        vSeeds.push_back(CDNSSeedData("blockoperations.com", "zpool.blockoperations.com"));
         vSeeds.push_back(CDNSSeedData("zenchain.info", "node1.zenchain.info"));
         vSeeds.push_back(CDNSSeedData("zenseed.network", "zenseed.network"));
 
@@ -254,6 +255,8 @@ public:
 
         vFixedSeeds.clear();
         vSeeds.clear();
+        vSeeds.push_back(CDNSSeedData("zensystem.io", "dnsseed.testnet.zensystem.io"));
+        vSeeds.push_back(CDNSSeedData("blockoperations.com", "zpool2.blockoperations.com"));
         vSeeds.push_back(CDNSSeedData("scottrockcafe.com", "node.scottrockcafe.com"));
 
         // guarantees the first 2 characters, when base58 encoded, are "zt"

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -261,6 +261,7 @@ public:
         vSeeds.push_back(CDNSSeedData("blockoperations.com", "zpool2.blockoperations.com"));
         vSeeds.push_back(CDNSSeedData("scottrockcafe.com", "node.scottrockcafe.com"));
         vSeeds.push_back(CDNSSeedData("zensystem.io", "testnet.zensystem.io"));
+
         // guarantees the first 2 characters, when base58 encoded, are "zt"
         // guarantees the first 2 characters, when base58 encoded, are "tm"
         base58Prefixes[PUBKEY_ADDRESS]     = {0x20,0x98};

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -110,9 +110,11 @@ public:
         vFixedSeeds.clear();
         vSeeds.clear();
         vSeeds.push_back(CDNSSeedData("zensystem.io", "dnsseed.zensystem.io"));
+        vSeeds.push_back(CDNSSeedData("zenseed.network", "dnsseed.zenseed.network"));
         vSeeds.push_back(CDNSSeedData("blockoperations.com", "zpool.blockoperations.com"));
         vSeeds.push_back(CDNSSeedData("zenchain.info", "node1.zenchain.info"));
         vSeeds.push_back(CDNSSeedData("zenseed.network", "zenseed.network"));
+        vSeeds.push_back(CDNSSeedData("zensystem.io", "mainnet.zensystem.io"));
 
         // guarantees the first 2 characters, when base58 encoded, are "zn"
         // guarantees the first 2 characters, when base58 encoded, are "t1"
@@ -258,7 +260,7 @@ public:
         vSeeds.push_back(CDNSSeedData("zensystem.io", "dnsseed.testnet.zensystem.io"));
         vSeeds.push_back(CDNSSeedData("blockoperations.com", "zpool2.blockoperations.com"));
         vSeeds.push_back(CDNSSeedData("scottrockcafe.com", "node.scottrockcafe.com"));
-
+        vSeeds.push_back(CDNSSeedData("zensystem.io", "testnet.zensystem.io"));
         // guarantees the first 2 characters, when base58 encoded, are "zt"
         // guarantees the first 2 characters, when base58 encoded, are "tm"
         base58Prefixes[PUBKEY_ADDRESS]     = {0x20,0x98};


### PR DESCRIPTION
I'd like to get this into master before creating new binary releases. The mainnet/testnet nodes and seeders under zensystem.io are not up yet, but should be in the next 2 days. `dnsseed.zenseed.network` was added with the assumption that @tarrenj will run his dnsseeder there, please adjust if this is not the case.