### PR TITLE
RPC validateaddress

### DIFF
--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -181,6 +181,7 @@ UniValue validateaddress(const UniValue& params, bool fHelp)
     string strAddress = params[0].get_str();
     CBitcoinAddress address(strAddress);
     bool isValid = address.IsValid();
+    // do not valid addr `t` addr via rpc only
     if (isValid && strAddress[0]=='t') {
         isValid = false;
     }

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -180,6 +180,9 @@ UniValue validateaddress(const UniValue& params, bool fHelp)
 
     CBitcoinAddress address(params[0].get_str());
     bool isValid = address.IsValid();
+    if (params[0].get_str()[0]=='t') {
+        isValid = false;
+    }
 
     UniValue ret(UniValue::VOBJ);
     ret.push_back(Pair("isvalid", isValid));

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -177,10 +177,11 @@ UniValue validateaddress(const UniValue& params, bool fHelp)
 #else
     LOCK(cs_main);
 #endif
-
-    CBitcoinAddress address(params[0].get_str());
+    
+    string strAddress = params[0].get_str();
+    CBitcoinAddress address(strAddress);
     bool isValid = address.IsValid();
-    if (params[0].get_str()[0]=='t') {
+    if (isValid && strAddress[0]=='t') {
         isValid = false;
     }
 


### PR DESCRIPTION
In order to help pool operator nodes reject invalid t-addr from authorized connections; do not validate addr that start with `t` via RPC calls only since they pass normal valid address verifications. This only effects the `validateaddress` RPC call only and does not effect any other address validation. Pre-fork coins should remain spendable.
```
zen@zen-dev:~$ zen-cli validateaddress t1f1xRt73TWgVWJQEFAW6DLwKtwmQvFahrN
{ 
    "isvalid": false
}
```
Thank you for your review.