### PR TITLE
Add Zen Blockchain Foundation copyright, update references

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,3 +1,4 @@
+Copyright (c) 2017 Zen Blockchain Foundation
 Copyright (c) 2017 Zdeveloper.org
 Copyright (c) 2016 The Zcash developers
 Copyright (c) 2009-2015 The Bitcoin Core developers

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ See important security warnings in
 
 Where do I begin?
 -----------------
-* The easiest way to get started is to download one of the available graphical wallets from [Zdeveloper.org](https://zdeveloper.org)
+* The easiest way to get started is to download one of the available graphical wallets from [zensystem.io](https://zensystem.io)
 
 ### Need Help?
 

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -1,14 +1,14 @@
 Source: zcash
 Section: utils
 Priority: optional
-Maintainer: ZenCash <josh@zencash.io>
-Homepage: https://zencash.io
+Maintainer: Zen Blockchain Foundation <cronic@zensystem.io>
+Homepage: https://zensystem.io
 Build-Depends: autoconf, automake, bsdmainutils, build-essential,
  git, g++-multilib, libc6-dev, libtool,
  m4, ncurses-dev, pkg-config, python,
  unzip, wget, zlib1g-dev
-Vcs-Git: https://github.com/zencashio/zen.git
-Vcs-Browser: https://github.com/zencashio/zen
+Vcs-Git: https://github.com/ZencashOfficial/zen.git
+Vcs-Browser: https://github.com/ZencashOfficial/zen
 
 Package: zen
 Version: 1.0.6

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -25,7 +25,7 @@ packages:
 - "wget"
 - "zlib1g-dev"
 remotes:
-- "url": "https://github.com/zencashio/zen.git"
+- "url": "https://github.com/ZencashOfficial/zen.git"
   "dir": "zen"
 files: []
 script: |

--- a/depends/packages/libgmp.mk
+++ b/depends/packages/libgmp.mk
@@ -1,5 +1,5 @@
 package=libgmp
-$(package)_download_path=https://github.com/z-classic/$(package)/archive/
+$(package)_download_path=https://github.com/ZencashOfficial/$(package)/archive/
 $(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
 $(package)_download_file=$($(package)_git_commit).tar.gz
 $(package)_sha256_hash=59b2c2b5d58fdf5943bfde1fa709e9eb53e7e072c9699d28dc1c2cbb3c8cc32c

--- a/depends/packages/libsnark.mk
+++ b/depends/packages/libsnark.mk
@@ -1,5 +1,5 @@
 package=libsnark
-$(package)_download_path=https://github.com/z-classic/$(package)/archive/
+$(package)_download_path=https://github.com/ZencashOfficial/$(package)/archive/
 $(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
 $(package)_download_file=$($(package)_git_commit).tar.gz
 

--- a/doc/man/zcash-cli.1
+++ b/doc/man/zcash-cli.1
@@ -68,6 +68,7 @@ Timeout in seconds during HTTP requests, or 0 for no timeout. (default:
 .SH COPYRIGHT
 Copyright \(co 2009\-2017 The Bitcoin Core Developers
 Copyright \(co 2015\-2017 The Zcash Developers
+Copyright \(co 2015\-2017 zdeveloper.org
 Copyright \(co 2015\-2017 Zen Blockchain Foundation
 
 

--- a/doc/man/zcash-cli.1
+++ b/doc/man/zcash-cli.1
@@ -68,7 +68,8 @@ Timeout in seconds during HTTP requests, or 0 for no timeout. (default:
 .SH COPYRIGHT
 Copyright \(co 2009\-2017 The Bitcoin Core Developers
 Copyright \(co 2015\-2017 The Zcash Developers
-Copyright \(co 2015\-2017 zdeveloper.org
+Copyright \(co 2015\-2017 Zen Blockchain Foundation
+
 
 This is experimental software.
 

--- a/doc/man/zcashd.1
+++ b/doc/man/zcashd.1
@@ -456,7 +456,7 @@ console, 600 otherwise)
 .SH COPYRIGHT
 Copyright \(co 2009\-2017 The Bitcoin Core Developers
 Copyright \(co 2015\-2017 The Zcash Developers
-Copyright \(co 2015\-2017 zdeveloper.org
+Copyright \(co 2015\-2017 Zen Blockchain Foundation
 
 This is experimental software.
 

--- a/doc/man/zcashd.1
+++ b/doc/man/zcashd.1
@@ -456,6 +456,7 @@ console, 600 otherwise)
 .SH COPYRIGHT
 Copyright \(co 2009\-2017 The Bitcoin Core Developers
 Copyright \(co 2015\-2017 The Zcash Developers
+Copyright \(co 2015\-2017 zdeveloper.org
 Copyright \(co 2015\-2017 Zen Blockchain Foundation
 
 This is experimental software.

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Copyright (c) 2016-2017 The Zcash developers
+// Copyright (c) 2017 Zen Blockchain Foundations
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -39,7 +40,7 @@
 #define DO_STRINGIZE(X) #X
 
 //! Copyright string used in Windows .rc files
-#define COPYRIGHT_STR "2009-" STRINGIZE(COPYRIGHT_YEAR) " The Bitcoin Core Developers and The Zcash developers"
+#define COPYRIGHT_STR "2009-" STRINGIZE(COPYRIGHT_YEAR) " The Bitcoin Core Developers, The Zcash developers, and Zen Blockchain Foundations"
 
 /**
  * bitcoind-res.rc includes this file, but it cannot cope with real c++ code.

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Copyright (c) 2016-2017 The Zcash developers
-// Copyright (c) 2017 Zen Blockchain Foundations
+// Copyright (c) 2017 Zen Blockchain Foundation
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -40,7 +40,7 @@
 #define DO_STRINGIZE(X) #X
 
 //! Copyright string used in Windows .rc files
-#define COPYRIGHT_STR "2009-" STRINGIZE(COPYRIGHT_YEAR) " The Bitcoin Core Developers, The Zcash developers, and Zen Blockchain Foundations"
+#define COPYRIGHT_STR "2009-" STRINGIZE(COPYRIGHT_YEAR) " The Bitcoin Core Developers, The Zcash developers, and Zen Blockchain Foundation"
 
 /**
  * bitcoind-res.rc includes this file, but it cannot cope with real c++ code.

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -901,6 +901,7 @@ std::string LicenseInfo()
            FormatParagraph(strprintf(_("Copyright (C) 2009-%i The Bitcoin Core Developers"), COPYRIGHT_YEAR)) + "\n" +
            FormatParagraph(strprintf(_("Copyright (C) 2015-%i The Zcash Developers"), COPYRIGHT_YEAR)) + "\n" +
            FormatParagraph(strprintf(_("Copyright (C) 2015-%i Zdeveloper.org"), COPYRIGHT_YEAR)) + "\n" +
+           FormatParagraph(strprintf(_("Copyright (C) 2015-%i Zen Blockchain Foundation"), COPYRIGHT_YEAR)) + "\n" +
            "\n" +
            FormatParagraph(_("This is experimental software.")) + "\n" +
            "\n" +


### PR DESCRIPTION
Updates references to the old git, adds copyright info and changes the dependency download urls for libsnark and libgmp from zclassic to our fork of the libraries.