### PR TITLE
Reject the most common types of transactions without op_cbah instead of a blanket ban on all non OP_CHECKBLOCKATHEIGHT txs 

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -61,6 +61,7 @@ public:
         consensus.sfReplayProtectionHeight = 117575;
         consensus.hfFoundersRewardHeight = INT_MAX;
         consensus.hfFixP2SHHeight = INT_MAX;
+	consensus.hfRejectCommonTX = INT_MAX;
 
         /**
          * ZEN Network Magic Start Value
@@ -263,6 +264,7 @@ public:
         consensus.sfReplayProtectionHeight = 72650;
         consensus.hfFoundersRewardHeight = 85500;
         consensus.hfFixP2SHHeight = 85500;
+	consensus.hfRejectCommonTX = 89500;
 
         pchMessageStart[0] = 0xbf;
         pchMessageStart[1] = 0xf2;
@@ -376,6 +378,7 @@ public:
         consensus.sfReplayProtectionHeight = 1100;
         consensus.hfFoundersRewardHeight = 1200;
         consensus.hfFixP2SHHeight = 1200;
+	consensus.hfRejectCommonTX = 1200;
 
         pchMessageStart[0] = 0x2f;
         pchMessageStart[1] = 0x54;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -91,6 +91,7 @@ struct Params {
     int sfReplayProtectionHeight;
     int hfFoundersRewardHeight;
     int hfFixP2SHHeight;
+    int hfRejectCommonTX;
 };
 } // namespace Consensus
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -675,20 +675,7 @@ bool IsStandardTx(const CTransaction& tx, string& reason)
             return false;
         }
 
-        int nHeight = chainActive.Height();
-        // provide temporary replay protection for two minerconf windows during chainsplit
-        // TODO: do we really need this check here?
-        if ((whichType != TX_PUBKEY_REPLAY &&
-             whichType != TX_PUBKEYHASH_REPLAY &&
-             whichType != TX_MULTISIG_REPLAY &&
-             whichType != TX_SCRIPTHASH_REPLAY) &&
-             nHeight > Params().GetConsensus().nChainsplitIndex &&
-            !tx.IsCoinBase())
-        {
-            reason = "op-checkblockatheight-needed";
-            return false;
-        }
-        else if (whichType == TX_NULL_DATA)
+        if (whichType == TX_NULL_DATA)
             nDataOut++;
         else if ((whichType == TX_MULTISIG) && (!fIsBareMultisigStd)) {
             reason = "bare-multisig";
@@ -874,10 +861,22 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state,
         txnouttype whichType;
         ::IsStandard(txout.scriptPubKey, whichType);
 
+        if ((whichType != TX_PUBKEY &&
+             whichType != TX_PUBKEYHASH &&
+             whichType != TX_MULTISIG &&
+             whichType != TX_SCRIPTHASH) &&
+             chainActive.Height() > Params().GetConsensus().hfFixP2SHHeight &&
+             !tx.IsCoinBase())
+        {
+            return state.DoS(100, error("%s: %s: op-checkblockatheight-needed. Tx id: %s", __FILE__, __func__, tx.GetHash().ToString()),
+                             REJECT_CHECKBLOCKATHEIGHT_NOT_FOUND, "op-checkblockatheight-needed");
+        }
+        
         if ((whichType != TX_PUBKEY_REPLAY &&
              whichType != TX_PUBKEYHASH_REPLAY &&
              whichType != TX_MULTISIG_REPLAY &&
              whichType != TX_SCRIPTHASH_REPLAY) &&
+             chainActive.Height() < Params().GetConsensus().hfFixP2SHHeight &&
              chainActive.Height() > Params().GetConsensus().sfReplayProtectionHeight &&
              !tx.IsCoinBase())
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -872,17 +872,16 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state,
                              REJECT_CHECKBLOCKATHEIGHT_NOT_FOUND, "op-checkblockatheight-needed");
         }
 
-        /*if ((whichType != TX_PUBKEY_REPLAY &&
+        if ((whichType != TX_PUBKEY_REPLAY &&
              whichType != TX_PUBKEYHASH_REPLAY &&
-             whichType != TX_MULTISIG_REPLAY &&
-             whichType != TX_SCRIPTHASH_REPLAY) &&
+             whichType != TX_MULTISIG_REPLAY) &&
              chainActive.Height() < Params().GetConsensus().hfFixP2SHHeight &&
              chainActive.Height() > Params().GetConsensus().sfReplayProtectionHeight &&
              !tx.IsCoinBase())
         {
             return state.DoS(100, error("%s: %s: op-checkblockatheight-needed. Tx id: %s", __FILE__, __func__, tx.GetHash().ToString()),
                              REJECT_CHECKBLOCKATHEIGHT_NOT_FOUND, "op-checkblockatheight-needed");
-        }*/
+        }
 
         /*if (whichType == TX_SCRIPTHASH_REPLAY &&
             chainActive.Height() < Params().GetConsensus().hfFixP2SHHeight)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -861,10 +861,10 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state,
         txnouttype whichType;
         ::IsStandard(txout.scriptPubKey, whichType);
 
-        if ((whichType != TX_PUBKEY &&
-             whichType != TX_PUBKEYHASH &&
-             whichType != TX_MULTISIG &&
-             whichType != TX_SCRIPTHASH) &&
+        if ((whichType == TX_PUBKEY &&
+             whichType == TX_PUBKEYHASH &&
+             whichType == TX_MULTISIG &&
+             whichType == TX_SCRIPTHASH) &&
              chainActive.Height() > Params().GetConsensus().hfFixP2SHHeight &&
              !tx.IsCoinBase())
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -861,18 +861,18 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state,
         txnouttype whichType;
         ::IsStandard(txout.scriptPubKey, whichType);
 
-        if ((whichType == TX_PUBKEY &&
-             whichType == TX_PUBKEYHASH &&
-             whichType == TX_MULTISIG &&
+        if ((whichType == TX_PUBKEY ||
+             whichType == TX_PUBKEYHASH ||
+             whichType == TX_MULTISIG ||
              whichType == TX_SCRIPTHASH) &&
-             chainActive.Height() > Params().GetConsensus().hfFixP2SHHeight &&
+             chainActive.Height() >= Params().GetConsensus().hfRejectCommonTX &&
              !tx.IsCoinBase())
         {
             return state.DoS(100, error("%s: %s: op-checkblockatheight-needed. Tx id: %s", __FILE__, __func__, tx.GetHash().ToString()),
                              REJECT_CHECKBLOCKATHEIGHT_NOT_FOUND, "op-checkblockatheight-needed");
         }
-        
-        if ((whichType != TX_PUBKEY_REPLAY &&
+
+        /*if ((whichType != TX_PUBKEY_REPLAY &&
              whichType != TX_PUBKEYHASH_REPLAY &&
              whichType != TX_MULTISIG_REPLAY &&
              whichType != TX_SCRIPTHASH_REPLAY) &&
@@ -882,14 +882,14 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state,
         {
             return state.DoS(100, error("%s: %s: op-checkblockatheight-needed. Tx id: %s", __FILE__, __func__, tx.GetHash().ToString()),
                              REJECT_CHECKBLOCKATHEIGHT_NOT_FOUND, "op-checkblockatheight-needed");
-        }
+        }*/
 
-        if (whichType == TX_SCRIPTHASH_REPLAY &&
+        /*if (whichType == TX_SCRIPTHASH_REPLAY &&
             chainActive.Height() < Params().GetConsensus().hfFixP2SHHeight)
         {
             return state.DoS(100, error("%s: %s: TX_SCRIPTHASH_REPLAY will be activated only after %d block. Transaction rejected. Tx id: %s", __FILE__, __func__, Params().GetConsensus().hfFixP2SHHeight, tx.GetHash().ToString()),
                              REJECT_CHECKBLOCKATHEIGHT_NOT_FOUND, "op-checkblockatheight-needed");
-        }
+        }*/
     }
 
     return true;


### PR DESCRIPTION
This way we can add new types of transactions without need checkblockatheight on them