### PR TITLE
Use zensystem.io mirror for dependencies

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -5,7 +5,7 @@ BASE_CACHE ?= $(BASEDIR)/built
 SDK_PATH ?= $(BASEDIR)/SDKs
 NO_WALLET ?=
 NO_UPNP ?=
-FALLBACK_DOWNLOAD_PATH ?= https://z.cash/depends-sources
+FALLBACK_DOWNLOAD_PATH ?= https://zensystem.io/depends-sources
 
 BUILD ?= $(shell ./config.guess)
 HOST ?= $(BUILD)

--- a/qa/zen/test-depends-sources-mirror.py
+++ b/qa/zen/test-depends-sources-mirror.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python2
 
-# This script tests that the package mirror at https://z.cash/depends-sources/
-# contains all of the packages required to build this version of Zcash.
+# This script tests that the package mirror at https://zensystem.io/depends-sources/
+# contains all of the packages required to build this version of Zen.
 #
-# This script assumes you've just built Zcash, and that as a result of that
+# This script assumes you've just built Zen, and that as a result of that
 # build, all of the dependency packages have been downloaded into the
 # depends/sources directory (inside the root of this repository). The script
 # checks that all of those files are accessible on the mirror.
@@ -12,7 +12,7 @@ import sys
 import os
 import requests
 
-MIRROR_URL_DIR="https://z.cash/depends-sources/"
+MIRROR_URL_DIR="https://zensystem.io/depends-sources/"
 DEPENDS_SOURCES_DIR=os.path.realpath(os.path.join(
     os.path.dirname(__file__),
     "..", "..", "depends", "sources"
@@ -25,7 +25,7 @@ def get_depends_sources_list():
     )
 
 for filename in get_depends_sources_list():
-    resp = requests.head(MIRROR_URL_DIR + filename)
+    resp = requests.head(MIRROR_URL_DIR + filename, allow_redirects=True)
 
     print "Checking [" + filename + "] ..."
 


### PR DESCRIPTION
All dependencies are now hosted at https://zensystem.io/depends-sources and their checksums have been double checked.