### PR TITLE
Update OpenSSL to 1.1.0f

### DIFF
--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,8 +1,8 @@
 package=openssl
-$(package)_version=1.1.0d
+$(package)_version=1.1.0f
 $(package)_download_path=https://www.openssl.org/source
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=7d5ebb9e89756545c156ff9c13cf2aa6214193b010a468a3bc789c3c28fe60df
+$(package)_sha256_hash=12f746f3f2493b2f39da7ecf63d7ee19c6ac9ec6a4fcd8c229da8a522cb12765
 
 define $(package)_set_vars
 $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"


### PR DESCRIPTION
Updates OpenSSL to Version 1.1.0f fixing [CVE-2017-3733](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-3733). This vulnerability does not affect the normal node software but might affect the [TLS_integration](https://github.com/ZencashOfficial/zen/tree/TLS_integration) branch.

This is a drop-in replacement and should not cause any problems. Functionality was tested on the TLS_integration branch.