### PR TITLE
Update chainparams.cpp

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -120,7 +120,7 @@ public:
         vSeeds.push_back(CDNSSeedData("zenseed.network", "dnsseed.zenseed.network"));
         vSeeds.push_back(CDNSSeedData("blockoperations.com", "zpool.blockoperations.com"));
         vSeeds.push_back(CDNSSeedData("zenchain.info", "node1.zenchain.info"));
-        vSeeds.push_back(CDNSSeedData("zenseed.network", "zenseed.network"));
+        vSeeds.push_back(CDNSSeedData("zenseed.network", "mainnet.zenseed.network"));
         vSeeds.push_back(CDNSSeedData("zensystem.io", "mainnet.zensystem.io"));
 
         // guarantees the first 2 characters, when base58 encoded, are "zn"


### PR DESCRIPTION
corrects from 'zenseed.network' to 'mainnet.zenseed.network'