### PR TITLE
Makes full-test-suite.sh work with zen

### DIFF
--- a/qa/zen/check-security-hardening.sh
+++ b/qa/zen/check-security-hardening.sh
@@ -30,11 +30,11 @@ function test_fortify_source {
 make -C "$REPOROOT/src" check-security
 
 test_rpath_runpath "${REPOROOT}/src/zend"
-test_rpath_runpath "${REPOROOT}/src/zen-cii"
+test_rpath_runpath "${REPOROOT}/src/zen-cli"
 test_rpath_runpath "${REPOROOT}/src/zen-gtest"
 test_rpath_runpath "${REPOROOT}/src/zen-tx"
 test_rpath_runpath "${REPOROOT}/src/test/test_bitcoin"
-#test_rpath_runpath "${REPOROOT}/src/zen/GenerateParams"
+test_rpath_runpath "${REPOROOT}/src/zcash/GenerateParams"
 
 # NOTE: checksec.sh does not reliably determine whether FORTIFY_SOURCE is
 # enabled for the entire binary. See issue #915.
@@ -43,4 +43,4 @@ test_fortify_source "${REPOROOT}/src/zen-cli"
 test_fortify_source "${REPOROOT}/src/zen-gtest"
 test_fortify_source "${REPOROOT}/src/zen-tx"
 test_fortify_source "${REPOROOT}/src/test/test_bitcoin"
-#test_fortify_source "${REPOROOT}/src/zen/GenerateParams"
+test_fortify_source "${REPOROOT}/src/zcash/GenerateParams"

--- a/qa/zen/full-test-suite.sh
+++ b/qa/zen/full-test-suite.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Execute all of the automated tests related to Zcash.
+# Execute all of the automated tests related to Zen.
 #
 
 set -eu
@@ -26,8 +26,8 @@ function run_test_phase
 cd "${REPOROOT}"
 
 # Test phases:
-run_test_phase "${REPOROOT}/qa/zcash/check-security-hardening.sh"
-run_test_phase "${REPOROOT}/qa/zcash/ensure-no-dot-so-in-depends.py"
+run_test_phase "${REPOROOT}/qa/zen/check-security-hardening.sh"
+run_test_phase "${REPOROOT}/qa/zen/ensure-no-dot-so-in-depends.py"
 
 # If make check fails, show test-suite.log as part of our run_test_phase
 # output (and fail the phase with false):

--- a/qa/zen/performance-measurements.sh
+++ b/qa/zen/performance-measurements.sh
@@ -5,17 +5,17 @@ set -e
 DATADIR=./benchmark-datadir
 
 function zcash_rpc {
-    ./src/zcash-cli -datadir="$DATADIR" -rpcwait -rpcuser=user -rpcpassword=password -rpcport=5983 "$@"
+    ./src/zen-cli -datadir="$DATADIR" -rpcwait -rpcuser=user -rpcpassword=password -rpcport=5983 "$@"
 }
 
 function zcash_rpc_slow {
     # Timeout of 1 hour
-    ./src/zcash-cli -datadir="$DATADIR" -rpcwait -rpcuser=user -rpcpassword=password -rpcport=5983 -rpcclienttimeout=3600 "$@"
+    ./src/zen-cli -datadir="$DATADIR" -rpcwait -rpcuser=user -rpcpassword=password -rpcport=5983 -rpcclienttimeout=3600 "$@"
 }
 
 function zcash_rpc_veryslow {
     # Timeout of 2.5 hours
-    ./src/zcash-cli -datadir="$DATADIR" -rpcwait -rpcuser=user -rpcpassword=password -rpcport=5983 -rpcclienttimeout=9000 "$@"
+    ./src/zen-cli -datadir="$DATADIR" -rpcwait -rpcuser=user -rpcpassword=password -rpcport=5983 -rpcclienttimeout=9000 "$@"
 }
 
 function zcashd_generate {
@@ -26,7 +26,7 @@ function zcashd_start {
     rm -rf "$DATADIR"
     mkdir -p "$DATADIR"
     touch "$DATADIR/zen.conf"
-    ./src/zcashd -regtest -datadir="$DATADIR" -rpcuser=user -rpcpassword=password -rpcport=5983 -showmetrics=0 &
+    ./src/zend -regtest -datadir="$DATADIR" -rpcuser=user -rpcpassword=password -rpcport=5983 -showmetrics=0 &
     ZCASHD_PID=$!
 }
 
@@ -40,7 +40,7 @@ function zcashd_massif_start {
     mkdir -p "$DATADIR"
     touch "$DATADIR/zen.conf"
     rm -f massif.out
-    valgrind --tool=massif --time-unit=ms --massif-out-file=massif.out ./src/zcashd -regtest -datadir="$DATADIR" -rpcuser=user -rpcpassword=password -rpcport=5983 -showmetrics=0 &
+    valgrind --tool=massif --time-unit=ms --massif-out-file=massif.out ./src/zend -regtest -datadir="$DATADIR" -rpcuser=user -rpcpassword=password -rpcport=5983 -showmetrics=0 &
     ZCASHD_PID=$!
 }
 
@@ -55,7 +55,7 @@ function zcashd_valgrind_start {
     mkdir -p "$DATADIR"
     touch "$DATADIR/zen.conf"
     rm -f valgrind.out
-    valgrind --leak-check=yes -v --error-limit=no --log-file="valgrind.out" ./src/zcashd -regtest -datadir="$DATADIR" -rpcuser=user -rpcpassword=password -rpcport=5983 -showmetrics=0 &
+    valgrind --leak-check=yes -v --error-limit=no --log-file="valgrind.out" ./src/zend -regtest -datadir="$DATADIR" -rpcuser=user -rpcpassword=password -rpcport=5983 -showmetrics=0 &
     ZCASHD_PID=$!
 }
 
@@ -188,7 +188,7 @@ case "$1" in
         case "$2" in
             gtest)
                 rm -f valgrind.out
-                valgrind --leak-check=yes -v --error-limit=no --log-file="valgrind.out" ./src/zcash-gtest
+                valgrind --leak-check=yes -v --error-limit=no --log-file="valgrind.out" ./src/zen-gtest
                 cat valgrind.out
                 rm -f valgrind.out
                 ;;

--- a/src/test/data/bitcoin-util-test.json
+++ b/src/test/data/bitcoin-util-test.json
@@ -1,39 +1,39 @@
 [
-  { "exec": "././zcash-tx",
+  { "exec": "././zen-tx",
     "args": ["-create"],
     "output_cmp": "blanktx.hex"
   },
-  { "exec": "./zcash-tx",
+  { "exec": "./zen-tx",
     "args": ["-"],
     "input": "blanktx.hex",
     "output_cmp": "blanktx.hex"
   },
-  { "exec": "./zcash-tx",
+  { "exec": "./zen-tx",
     "args": ["-", "delin=1"],
     "input": "tx394b54bb.hex",
     "output_cmp": "tt-delin1-out.hex"
   },
-  { "exec": "./zcash-tx",
+  { "exec": "./zen-tx",
     "args": ["-", "delin=31"],
     "input": "tx394b54bb.hex",
     "return_code": 1
   },
-  { "exec": "./zcash-tx",
+  { "exec": "./zen-tx",
     "args": ["-", "delout=1"],
     "input": "tx394b54bb.hex",
     "output_cmp": "tt-delout1-out.hex"
   },
-  { "exec": "./zcash-tx",
+  { "exec": "./zen-tx",
     "args": ["-", "delout=2"],
     "input": "tx394b54bb.hex",
     "return_code": 1
   },
-  { "exec": "./zcash-tx",
+  { "exec": "./zen-tx",
     "args": ["-", "locktime=317000"],
     "input": "tx394b54bb.hex",
     "output_cmp": "tt-locktime317000-out.hex"
   },
-  { "exec": "./zcash-tx",
+  { "exec": "./zen-tx",
     "args":
     ["-create",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
@@ -43,11 +43,11 @@
      "outaddr=4:t1g1aXFye74HKJ24VviTxo3AW4BZbyCni5H"],
     "output_cmp": "txcreate1.hex"
   },
-  { "exec": "./zcash-tx",
+  { "exec": "./zen-tx",
     "args": ["-create", "outscript=0:"],
     "output_cmp": "txcreate2.hex"
   },
-  { "exec": "./zcash-tx",
+  { "exec": "./zen-tx",
     "args":
     ["-create",
      "in=4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485:0",


### PR DESCRIPTION
- qa/zen/full-test-suite.sh now runs additional tests + gtest
- qa/zen/performance-measurements.sh now works (if valgrind is installed)