### PR TITLE
Add option to limit debug.log size

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -459,6 +459,7 @@ std::string HelpMessage(HelpMessageMode mode)
             "This is intended for regression testing tools and app development.");
     }
     strUsage += HelpMessageOpt("-shrinkdebugfile", _("Shrink debug.log file on client startup (default: 1 when no -debug)"));
+    strUsage += HelpMessageOpt("-limitdebuglogsize", _("Limit the debug.log file size to 10Mb (default: 1 when no -debug)"));
     strUsage += HelpMessageOpt("-testnet", _("Use the test network"));
 
     strUsage += HelpMessageGroup(_("Node relay options:"));
@@ -1054,6 +1055,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 #ifndef WIN32
     CreatePidFile(GetPidFile(), getpid());
 #endif
+    fLimitDebugLogSize = GetBoolArg("-limitdebuglogsize", !fDebug);
+
     if (GetBoolArg("-shrinkdebugfile", !fDebug))
         ShrinkDebugFile();
 

--- a/src/util.h
+++ b/src/util.h
@@ -46,6 +46,7 @@ extern std::map<std::string, std::vector<std::string> > mapMultiArgs;
 extern bool fDebug;
 extern bool fPrintToConsole;
 extern bool fPrintToDebugLog;
+extern bool fLimitDebugLogSize;
 extern bool fServer;
 extern std::string strMiscWarning;
 extern bool fLogTimestamps;


### PR DESCRIPTION
- Added option `limitdebuglogsize` which defaults to 1 unless debug mode is on.
- When `limitdebuglogsize` is set, every time we try to write to the debug log, we check if we need to shrink it.
- Renamed `fileout` to `debugLogFp` as there is a `fileout` used by function `FileCommit` in the same file.

Technically this fixes a potential node DoS exploit. By causing a node to log endlessly, it could fill up the entire disk resulting in the node to crash and not come back online.

Closes #75 