### PR TITLE
Fix TLS DoS issue #93

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -397,6 +397,7 @@ CNode* FindNode(const CService& addr)
 static int WaitFor(SSLConnectionRoutine eRoutine, SOCKET hSocket, SSL *ssl, int timeoutSec)
 {
     int nErr = 0;
+    ERR_clear_error(); // clear the error queue
 
     while (true)
     {
@@ -938,6 +939,7 @@ void SocketSendData(CNode *pnode)
 
             if (bIsSSL)
             {
+                ERR_clear_error(); // clear the error queue, otherwise we may be reading an old error that occurred previously in the current thread
                 nBytes = SSL_write(pnode->ssl, &data[pnode->nSendOffset], data.size() - pnode->nSendOffset);
                 nRet = SSL_get_error(pnode->ssl, nBytes);
             }
@@ -1601,6 +1603,7 @@ void ThreadSocketHandler()
 
                             if (bIsSSL)
                             {
+                                ERR_clear_error(); // clear the error queue, otherwise we may be reading an old error that occurred previously in the current thread
                                 nBytes = SSL_read(pnode->ssl, pchBuf, sizeof(pchBuf));
                                 nRet = SSL_get_error(pnode->ssl, nBytes);
                             }
@@ -2444,6 +2447,7 @@ static bool TLSInitialize()
     // Initialization routines for the OpenSSL library
     //
     SSL_load_error_strings();
+    ERR_load_crypto_strings();
     OpenSSL_add_ssl_algorithms(); // OpenSSL_add_ssl_algorithms() always returns "1", so it is safe to discard the return value.
 
     namespace fs = boost::filesystem;


### PR DESCRIPTION
The error queue should be cleared before each SSL_connect(),
SSL_accept(), SSL_do_handshake(), SSL_read(), SSL_peek(), or
SSL_write() that is followed by a SSL_get_error(), otherwise
we may be reading an old error that occurred previously.

issue #93 