### PR TITLE
Fix compile on Gentoo Linux

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -36,9 +36,9 @@ define $(package)_config_cmds
 endef
 
 define $(package)_build_cmds
-  ./b2 -d2 -j2 -d1 --prefix=$($(package)_staging_prefix_dir) $($(package)_config_opts) stage
+  ./b2 -d2 -j2 -d1 --ignore-site-config --prefix=$($(package)_staging_prefix_dir) $($(package)_config_opts) stage
 endef
 
 define $(package)_stage_cmds
-  ./b2 -d0 -j4 --prefix=$($(package)_staging_prefix_dir) $($(package)_config_opts) install
+  ./b2 -d0 -j4 --ignore-site-config --prefix=$($(package)_staging_prefix_dir) $($(package)_config_opts) install
 endef


### PR DESCRIPTION
Not clear yet if this impacts other Linux compiles. This flag is needed to compile on Gentoo.

