### PR TITLE
Remove Bitcoin Core from error message

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2291,7 +2291,9 @@ bool BindListenPort(const CService &addrBind, string& strError, bool fWhiteliste
     {
         int nErr = WSAGetLastError();
         if (nErr == WSAEADDRINUSE)
-            strError = strprintf(_("Unable to bind to %s on this computer. Bitcoin Core is probably already running."), addrBind.ToString());
+            // ZEN_MOD_START
+            strError = strprintf(_("Unable to bind to %s on this computer. Zen is probably already running."), addrBind.ToString());
+            // ZEN_MOD_END
         else
             strError = strprintf(_("Unable to bind to %s on this computer (bind returned error %s)"), addrBind.ToString(), NetworkErrorString(nErr));
         LogPrintf("%s\n", strError);


### PR DESCRIPTION
when trying to start zend when it is already this error message appears indicating Bitcoin Core is already running